### PR TITLE
fix(connection): log out error on external wallets and duplicate disp…

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { ReactNode } from "react";
+import {ReactNode, useEffect} from "react";
 import { Tenant } from "@/config/tenant";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { WagmiProvider } from "wagmi";
+import {useAccount, useSwitchChain, WagmiProvider} from "wagmi";
 import { PrivyProvider } from "@privy-io/react-auth";
 import { WagmiProvider as PrivyWagmiProvider } from "@privy-io/wagmi";
 import { SmartWalletsProvider } from "@privy-io/react-auth/smart-wallets";
@@ -63,4 +63,21 @@ export default function ContextProvider({ children, tenant, initialState }: Prop
       </QueryClientProvider>
     </PrivyProvider>
   );
+}
+export function ChainGuard() {
+  const { chainId, isConnected } = useAccount();
+  const { switchChain } = useSwitchChain();
+
+  useEffect(() => {
+    // Only enforce in dev mode to avoid annoying users in prod
+    if (process.env.NEXT_PUBLIC_APP_ENV !== "development") return;
+
+    // If connected, but to the wrong chain (e.g., 31337 instead of 84532)
+    if (isConnected && chainId && chainId !== defaultChain.id) {
+      console.log(`[ChainGuard] Mismatch detected. Switching from ${chainId} to ${defaultChain.id}`);
+      switchChain({ chainId: defaultChain.id });
+    }
+  }, [chainId, isConnected, switchChain]);
+
+  return null;
 }

--- a/src/components/debug/NetworkDebugger.tsx
+++ b/src/components/debug/NetworkDebugger.tsx
@@ -15,7 +15,7 @@ export const NetworkDebugger = () => {
   if (!address) return null;
 
   return (
-    <div className="fixed bottom-18 right-6 p-4 bg-black/90 text-white text-[10px] font-mono rounded-2xl z-[9999] border border-white/10 shadow-2xl backdrop-blur-md w-64 animate-in fade-in slide-in-from-bottom-2">
+    <div className="fixed bottom-18 right-6 p-4 bg-black/90 text-white text-[10px] font-mono rounded-2xl z-9999 border border-white/10 shadow-2xl backdrop-blur-md w-64 animate-in fade-in slide-in-from-bottom-2">
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-bold text-indigo-400 flex items-center gap-2">
           <span className="relative flex h-2 w-2">

--- a/src/components/disputes/BalanceCard.tsx
+++ b/src/components/disputes/BalanceCard.tsx
@@ -34,7 +34,7 @@ export const BalanceCard: React.FC = () => {
   return (
     <>
       {/* Added 'relative' here to position the refresh button */}
-      <div className="relative bg-[#1b1c23] rounded-[21px] pt-[26px] px-[28px] pb-6 mt-[50px] mx-5 w-auto min-h-[110px] flex flex-row justify-between items-end text-white box-border">
+      <div className="relative bg-[#1b1c23] rounded-[21px] pt-6 px-6 pb-6 mt-12 mx-5 w-auto min-h-28 flex flex-row justify-between items-end text-white box-border">
         {/* Top Right Refresh Button */}
         <button
           onClick={() => refetch()}
@@ -46,7 +46,7 @@ export const BalanceCard: React.FC = () => {
 
         {/* Left Section */}
         <div className="flex flex-col gap-2.5 items-start flex-1 justify-start">
-          <div className="flex flex-col gap-[9px] w-auto mb-0">
+          <div className="flex flex-col gap-2 w-auto mb-0">
             <div className="font-manrope font-semibold text-[13px] leading-none opacity-70 tracking-[-0.26px] text-white">
               Balance
             </div>

--- a/src/hooks/core/useSliceConnect.ts
+++ b/src/hooks/core/useSliceConnect.ts
@@ -1,14 +1,26 @@
 import { usePrivy } from "@privy-io/react-auth";
+import { useDisconnect } from "wagmi";
 
 export const useSliceConnect = () => {
-  const { login, logout } = usePrivy();
+  const { login, logout: privyLogout } = usePrivy();
+  const { disconnect: wagmiDisconnect } = useDisconnect();
 
   const connect = async () => {
     login();
   };
 
   const disconnect = async () => {
-    await logout();
+    // 1. Try Privy Logout (Server-side session kill)
+    // We wrap this in a try/catch so a 400 error (missing token) doesn't stop execution
+    try {
+      await privyLogout();
+    } catch (e) {
+      console.warn("Privy logout warning (session might be already inactive):", e);
+    }
+
+    // 2. Force Wagmi Disconnect (Client-side wallet kill)
+    // This is crucial for MetaMask to update the UI (isConnected: false)
+    wagmiDisconnect();
   };
 
   return {

--- a/src/hooks/disputes/useDisputeList.ts
+++ b/src/hooks/disputes/useDisputeList.ts
@@ -56,17 +56,11 @@ export function useDisputeList(
     const contracts = [];
     let idsToFetch: bigint[] = [];
 
-    if (listType === "juror" && jurorDisputeIds) {
-      const ids = Array.from(jurorDisputeIds as bigint[]);
-      for (const id of ids) {
-        contracts.push({
-          address: sliceContract,
-          abi: SLICE_ABI,
-          functionName: "disputes",
-          args: [id],
-        });
-      }
-    } else if (listType === "all" && totalCount) {
+    // REMOVED: Redundant 'if (listType === "juror")' block that was causing duplicates.
+    // We only keep the logic for "all" here because it relies on a count/range
+    // rather than a specific ID list which is handled below.
+
+    if (listType === "all" && totalCount) {
       const total = Number(totalCount);
 
       const start = total;
@@ -146,7 +140,9 @@ export function useDisputeList(
       // --- Filter out Finished disputes if activeOnly is true ---
       if (options?.activeOnly) {
         // Status 3 = Finished/Resolved
-        finalDisputes = finalDisputes.filter((d) => d.status !== DISPUTE_STATUS.RESOLVED);
+        finalDisputes = finalDisputes.filter(
+          (d) => d.status !== DISPUTE_STATUS.RESOLVED,
+        );
       }
 
       setDisputes(finalDisputes);
@@ -154,7 +150,7 @@ export function useDisputeList(
     }
 
     process();
-  }, [results, isMulticallLoading, options?.activeOnly]);
+  }, [results, isMulticallLoading, options?.activeOnly, decimals]);
 
   return { disputes, isLoading: isMulticallLoading || isProcessing, refetch };
 }


### PR DESCRIPTION
<p align="center">
  <img src="https://raw.githubusercontent.com/sliceprotocol/slice/main/public/images/slice-logo.png" alt="Slice Logo" width="200" />
</p>

## Pull Request | Slice

### 📝 Summary

This pull request introduces several improvements across authentication, network handling, UI consistency, and dispute list logic. The most notable changes include a more robust disconnect flow for authentication, automatic chain switching in development, and code cleanups to prevent duplicate dispute entries.

**Authentication and Wallet Disconnect Improvements**
* Enhanced the `disconnect` logic in `useSliceConnect` to first attempt Privy logout (with error handling for inactive sessions) and then forcibly disconnect the wallet using Wagmi, ensuring reliable UI updates for wallet state.

**Network and Chain Handling**
* Added a `ChainGuard` component that automatically switches the user's chain to the default when in development mode if a mismatch is detected, improving developer experience and preventing network errors during local testing.

**Dispute List Logic Cleanup**
* Removed redundant logic in `useDisputeList` that caused duplicate dispute entries for jurors, streamlining how disputes are fetched and ensuring correct results.
* Updated the dependencies in the dispute filtering effect to include `decimals`, ensuring that disputes are reprocessed correctly when relevant data changes.

**UI Consistency and Minor Fixes**
* Standardized spacing, padding, and gap values in the `BalanceCard` component for a more consistent and visually appealing layout. [[1]](diffhunk://#diff-310c8c6d4d8a5a28d8b56173f7601569a89536979a3894e58c47a5dd72a7e033L37-R37) [[2]](diffhunk://#diff-310c8c6d4d8a5a28d8b56173f7601569a89536979a3894e58c47a5dd72a7e033L49-R49)
* Fixed the `z-index` value in `NetworkDebugger` for proper stacking order and visibility.